### PR TITLE
SSH support

### DIFF
--- a/main.go
+++ b/main.go
@@ -40,13 +40,14 @@ func (g *Git) Load(
 	return &Repo{
 		State:    state,
 		Worktree: worktree,
+		Git:      g,
 	}, nil
 }
 
 // Initialize a git repository
 func (g *Git) Init() *Repo {
 	return &Repo{
-		State: container().
+		State: g.container().
 			WithDirectory(gitStatePath, dag.Directory()).
 			WithExec([]string{
 				"git", "--git-dir=" + gitStatePath,
@@ -59,7 +60,7 @@ func (g *Git) Init() *Repo {
 
 // Clone a remote git repository
 func (g *Git) Clone(ctx context.Context, url string) *Repo {
-	clone := container().
+	clone := g.container().
 		WithWorkdir("/tmp").
 		WithExec([]string{"git", "clone", url, "src"}).
 		Directory("src")
@@ -68,7 +69,7 @@ func (g *Git) Clone(ctx context.Context, url string) *Repo {
 		With(clone.Directory(".git"), clone.WithoutDirectory(".git"))
 }
 
-func container() *Container {
+func (g *Git) container() *Container {
 	return dag.
 		Wolfi().
 		Container(WolfiContainerOpts{

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 )
 
 const (
@@ -14,25 +13,7 @@ const (
 	gitFilterRepoURL    = "https://raw.githubusercontent.com/newren/git-filter-repo/" + gitFilterRepoCommit + "/git-filter-repo"
 )
 
-type Git struct {
-	// +private
-	KnownHosts []string
-}
-
-func New(
-	// +optional
-	knownHost []string,
-) *Git {
-	return &Git{
-		KnownHosts: knownHost,
-	}
-}
-
-func (g *Git) WithKnownHost(host string) *Git {
-	return &Git{
-		KnownHosts: append(g.KnownHosts, host),
-	}
-}
+type Git struct{}
 
 // Load the contents of a git repository
 func (g *Git) Load(
@@ -104,15 +85,6 @@ func (g *Git) container() *Container {
 				Permissions: 0755,
 			},
 		).
-		With(func(c *Container) *Container {
-			if len(g.KnownHosts) > 0 {
-				c = c.WithExec([]string{"mkdir", "-p", "/root/.ssh"})
-
-				for _, host := range g.KnownHosts {
-					c = c.WithExec([]string{"sh", "-c", fmt.Sprintf("ssh-keyscan %s >> /root/.ssh/known_hosts", host)})
-				}
-			}
-
-			return c
-		})
+		WithMountedCache("/root/.ssh", dag.CacheVolume("git-known-hosts")).
+		WithEnvVariable("GIT_SSH_COMMAND", "ssh -o StrictHostKeyChecking=accept-new")
 }

--- a/main.go
+++ b/main.go
@@ -1,7 +1,10 @@
 // Git as a Dagger Module
 package main
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 const (
 	gitStatePath    = "/git/state"
@@ -11,7 +14,25 @@ const (
 	gitFilterRepoURL    = "https://raw.githubusercontent.com/newren/git-filter-repo/" + gitFilterRepoCommit + "/git-filter-repo"
 )
 
-type Git struct{}
+type Git struct {
+	// +private
+	KnownHosts []string
+}
+
+func New(
+	// +optional
+	knownHost []string,
+) *Git {
+	return &Git{
+		KnownHosts: knownHost,
+	}
+}
+
+func (g *Git) WithKnownHost(host string) *Git {
+	return &Git{
+		KnownHosts: append(g.KnownHosts, host),
+	}
+}
 
 // Load the contents of a git repository
 func (g *Git) Load(
@@ -55,6 +76,7 @@ func (g *Git) Init() *Repo {
 			}).
 			Directory(gitStatePath),
 		Worktree: dag.Directory(),
+		Git:      g,
 	}
 }
 
@@ -73,7 +95,7 @@ func (g *Git) container() *Container {
 	return dag.
 		Wolfi().
 		Container(WolfiContainerOpts{
-			Packages: []string{"git", "openssh", "python3"},
+			Packages: []string{"git", "openssh-client", "openssh-keyscan", "python3"},
 		}).
 		WithFile(
 			"/bin/git-filter-repo",
@@ -81,5 +103,16 @@ func (g *Git) container() *Container {
 			ContainerWithFileOpts{
 				Permissions: 0755,
 			},
-		)
+		).
+		With(func(c *Container) *Container {
+			if len(g.KnownHosts) > 0 {
+				c = c.WithExec([]string{"mkdir", "-p", "/root/.ssh"})
+
+				for _, host := range g.KnownHosts {
+					c = c.WithExec([]string{"sh", "-c", fmt.Sprintf("ssh-keyscan %s >> /root/.ssh/known_hosts", host)})
+				}
+			}
+
+			return c
+		})
 }

--- a/repository.go
+++ b/repository.go
@@ -9,12 +9,14 @@ import (
 type Repo struct {
 	State    *Directory
 	Worktree *Directory
+
+	Git *Git
 }
 
 // Open an interactive terminal,
 // with the repository available for inspection
 func (r *Repo) Inspect() *Terminal {
-	return container().
+	return r.Git.container().
 		WithDirectory("/src", r.Worktree).
 		WithDirectory("/src/.git", r.State).
 		WithWorkdir("/src").
@@ -33,7 +35,7 @@ func (r *Repo) Checkout(
 	// The git ref to checkout
 	ref string,
 ) *Repo {
-	return r.WithCommand([]string{"git", "checkout", ref})
+	return r.WithCommand([]string{"checkout", ref})
 }
 
 // Change properties of the repository
@@ -71,6 +73,7 @@ func (r *Repo) Command(args []string) *GitCommand {
 	return &GitCommand{
 		Args:  args,
 		Input: r,
+		Git:   r.Git,
 	}
 }
 
@@ -78,12 +81,15 @@ func (r *Repo) Command(args []string) *GitCommand {
 type GitCommand struct {
 	Args  []string
 	Input *Repo
+
+	// +private
+	Git *Git
 }
 
 func (cmd *GitCommand) container() *Container {
 	prefix := []string{"git", "--git-dir=" + gitStatePath, "--work-tree=" + gitWorktreePath}
 	execArgs := append(prefix, cmd.Args...)
-	return container().
+	return cmd.Git.container().
 		WithDirectory(gitStatePath, cmd.Input.State).
 		WithDirectory(gitWorktreePath, cmd.Input.Worktree).
 		WithExec(execArgs)
@@ -111,6 +117,7 @@ func (cmd *GitCommand) Output() *Repo {
 	return &Repo{
 		State:    container.Directory(gitStatePath),
 		Worktree: container.Directory(gitWorktreePath),
+		Git:      cmd.Git,
 	}
 }
 

--- a/repository.go
+++ b/repository.go
@@ -10,6 +10,7 @@ type Repo struct {
 	State    *Directory
 	Worktree *Directory
 
+	// +private
 	Git *Git
 }
 


### PR DESCRIPTION
This PR improves SSH support in general and lays the groundwork for push support discussed in https://github.com/dagger/dagger/issues/7202

I wanted to get an early feedback about:

- passing around the Git struct for shared state a container creation
- known hosts (prone to MITM attacks)

There is a better, but GitHub specific solution for known hosts: https://serverfault.com/a/1098531